### PR TITLE
fix allowed_push_host valid URI

### DIFF
--- a/notification-hub-client.gemspec
+++ b/notification-hub-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = "http://gems.truckpad.io"
   else
     raise "RubyGems 2.0 or newer is required to protect against " \
       "public gem pushes."


### PR DESCRIPTION
Corrigindo warning que começou a ser intolerado pelo instalador de gems:

```shell
The gemspec at
/usr/local/bundle/bundler/gems/notification-hub-client-8bccaa8c150a/notification-hub-client.gemspec
is not valid. Please fix this gemspec.
The validation error was '"TODO: Put your gem's website or public repo URL
here." is not a valid HTTP URI'
```